### PR TITLE
Fix: missing justify-center

### DIFF
--- a/src/components/ImageView/ModalInner.tsx
+++ b/src/components/ImageView/ModalInner.tsx
@@ -81,7 +81,7 @@ export default function ModalInner(props: ModalBackgroundProps) {
       }}
     >
       {/* <Close /> */}
-      <div className="flex h-full w-full items-center">
+      <div className="flex h-full w-full items-center justify-center">
         <animated.div
           ref={divRef}
           style={{


### PR DESCRIPTION
ImageView did not show image on center because of missing justify-center class.